### PR TITLE
add kitchen ci and travis support [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ tests/build/
 *.swp
 *.pyc
 .ropeproject
+.venv/
+srv/
+.kitchen
+.vendor
+Gemfile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,7 +2,7 @@
 driver:
   name: docker
   hostname: git.ci.local
-  use_sudo: true
+  use_sudo: false
 
 provisioner:
   name: salt_solo

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,52 @@
+---
+driver:
+  name: docker
+  hostname: git.ci.local
+  use_sudo: true
+
+provisioner:
+  name: salt_solo
+  salt_install: bootstrap
+  salt_bootstrap_url: https://bootstrap.saltstack.com
+  salt_version: latest
+  require_chef: false
+  dependencies:
+    - name: linux
+      repo: git
+      source: https://github.com/salt-formulas/salt-formula-linux
+  log_level: error
+  formula: git
+  grains:
+    noservices: True
+  state_top:
+    base:
+      "*":
+        - git
+  pillars:
+    top.sls:
+      base:
+        "*":
+          - git
+verifier:
+  name: inspec
+  sudo: true
+
+platforms:
+  - name: ubuntu-trusty
+    driver_config:
+      image: trevorj/salty-whales:trusty
+      platform: ubuntu
+
+  - name: ubuntu-xenial
+    driver_config:
+      image: trevorj/salty-whales:xenial
+      platform: ubuntu
+
+suites:
+
+  - name: client_single
+    provisioner:
+      pillars-from-files:
+        git.sls: tests/pillar/client_single.sls
+
+# vim: ft=yaml sw=2 ts=2 sts=2 tw=125

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - |
     test -e Gemfile || cat <<EOF > Gemfile
     source 'https://rubygems.org'
+    gem 'rake'
     gem 'test-kitchen'
     gem 'kitchen-docker'
     gem 'kitchen-inspec'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+services:
+  - docker
+
+install:
+  - pip install PyYAML
+  - pip install virtualenv
+  - |
+    test -e Gemfile || cat <<EOF > Gemfile
+    source 'https://rubygems.org'
+    gem 'test-kitchen'
+    gem 'kitchen-docker'
+    gem 'kitchen-inspec'
+    gem 'inspec'
+    gem 'kitchen-salt', :git => 'https://github.com/epcim/kitchen-salt.git', :branch => 'dependencis-pkg-repo2'
+    #Waiting for PR#78
+    #gem 'kitchen-salt', '>=0.2.25'
+  - bundle install
+
+before_script:
+  - make test
+
+script:
+  - test ! -e .kitchen.yml || bundle exec kitchen test

--- a/README.rst
+++ b/README.rst
@@ -77,3 +77,31 @@ Any questions or feedback is always welcome so feel free to join our IRC
 channel:
 
     #salt-formulas @ irc.freenode.net
+
+Testing
+=======
+
+`Salt formula testing <https://salt-formulas.readthedocs.io/en/latest/develop/testing-formulas.html>`_ and
+automated CI is covered in the main `documentation <https://salt-formulas.readthedocs.io/en/latest/develop/testing.html>`_.
+
+To run a local smoke test run:
+
+.. code-block:: shell
+
+  $ make test
+
+To run a local multiplatform rehearsal test run:
+
+.. code-block:: shell
+
+  $ kitchen list
+
+  Instance                    Driver   Provisioner  Verifier  Transport  Last Action
+
+  client-single-ubuntu-1404   Docker   SaltSolo     Inspec    Ssh        Verified
+  client-single-ubuntu-1604   Docker   SaltSolo     Inspec    Ssh        Converged
+  client-single-centos-71     Docker   SaltSolo     Inspec    Ssh        <Not Created>
+
+  $ kitchen converge [instance]
+  $ kitchen verify [instance]
+

--- a/README.rst
+++ b/README.rst
@@ -77,31 +77,3 @@ Any questions or feedback is always welcome so feel free to join our IRC
 channel:
 
     #salt-formulas @ irc.freenode.net
-
-Testing
-=======
-
-`Salt formula testing <https://salt-formulas.readthedocs.io/en/latest/develop/testing-formulas.html>`_ and
-automated CI is covered in the main `documentation <https://salt-formulas.readthedocs.io/en/latest/develop/testing.html>`_.
-
-To run a local smoke test run:
-
-.. code-block:: shell
-
-  $ make test
-
-To run a local multiplatform rehearsal test run:
-
-.. code-block:: shell
-
-  $ kitchen list
-
-  Instance                    Driver   Provisioner  Verifier  Transport  Last Action
-
-  client-single-ubuntu-1404   Docker   SaltSolo     Inspec    Ssh        Verified
-  client-single-ubuntu-1604   Docker   SaltSolo     Inspec    Ssh        Converged
-  client-single-centos-71     Docker   SaltSolo     Inspec    Ssh        <Not Created>
-
-  $ kitchen converge [instance]
-  $ kitchen verify [instance]
-

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,6 +1,6 @@
 name: "git"
 version: "0.2"
-source: "https://github.com/tcpcloud/salt-formula-git"
+source: "https://github.com/salt-formulas/salt-formula-git"
 dependencies:
 - name: linux
-  source: "https://github.com/tcpcloud/salt-formula-linux"
+  source: "https://github.com/salt-formulas/salt-formula-linux"

--- a/tests/pillar/client_single.sls
+++ b/tests/pillar/client_single.sls
@@ -14,5 +14,3 @@ linux:
         sudo: true
         full_name: John Doe
         home: /home/jdoe
-        password:
-          passw0rd

--- a/tests/pillar/client_single.sls
+++ b/tests/pillar/client_single.sls
@@ -1,6 +1,18 @@
 git:
   client:
     enabled: true
+    user:
+    - user:
+        name: jdoe
+        email: j@doe.com
 linux:
   system:
     enabled: true
+    user:
+      jdoe:
+        enabled: true
+        sudo: true
+        full_name: John Doe
+        home: /home/jdoe
+        password:
+          passw0rd


### PR DESCRIPTION
Add kitchen CI.
Add travis builds.

Uses features from https://github.com/simonmcc/kitchen-salt/pull/78 (in other words it allow resolve and install multiple formula dependencies from git/spm/apt/yum.

Ready for comments. It's WIP but fully works.

This formula is being used for kitchen-salt build verification.