### PR TITLE
Switch git-core to git

### DIFF
--- a/git/map.jinja
+++ b/git/map.jinja
@@ -29,7 +29,7 @@
         'pkgs': ['git'],
     },
     'Debian': {
-        'pkgs': ['git-core'],
+        'pkgs': ['git'],
     },
     'Gentoo': {
         'pkgs': ['dev-vcs/git'],


### PR DESCRIPTION
Starting with the Fluorine release, virtual packages won't be supported, so this will need to be `git` instead of `git-core`