### PR TITLE
Fix obsolete virtual pkg name.

### DIFF
--- a/git/map.jinja
+++ b/git/map.jinja
@@ -29,7 +29,7 @@
         'pkgs': ['git'],
     },
     'Debian': {
-        'pkgs': ['git-core'],
+        'pkgs': ['git'],
     },
     'Gentoo': {
         'pkgs': ['dev-vcs/git'],


### PR DESCRIPTION
git-core package is marked obsolete in Ubuntu and is contained in git package.